### PR TITLE
MediaStreamRecordingのRecord APIの仕様修正

### DIFF
--- a/api/mediaStreamRecording.json
+++ b/api/mediaStreamRecording.json
@@ -1396,6 +1396,7 @@
                     "description": "レコーディング情報",
                     "required": [
                         "status",
+                        "uri",
                         "path",
                         "mimeType"
                     ],

--- a/api/mediaStreamRecording.json
+++ b/api/mediaStreamRecording.json
@@ -1446,6 +1446,11 @@
                             "type": "string",
                             "title": "URI",
                             "description": "動画または音声のURI。"
+                        },
+                        "path": {
+                            "type": "string",
+                            "title": "ファイルパス",
+                            "description": "動画または音声へのファイルパス。ルートはデバイスプラグインごとに異なる。File APIのパラメータとして使用可能。"
                         }
                     }
                 }

--- a/api/mediaStreamRecording.json
+++ b/api/mediaStreamRecording.json
@@ -301,7 +301,7 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/RecorderControlResponse"
+                            "$ref": "#/definitions/RecorderStopResponse"
                         },
                         "examples": {
                             "application/json": {
@@ -1151,10 +1151,6 @@
                 },
                 {
                     "type": "object",
-                    "required": [
-                        "uri",
-                        "path"
-                    ],
                     "properties": {
                         "uri": {
                             "type": "string",
@@ -1410,10 +1406,15 @@
                             "description": "レコーディングの状態を識別する文字列。",
                             "enum": ["recording", "stop", "pause", "resume", "mutetrack", "unmutetrack", "error", "warning"]
                         },
+                        "uri": {
+                            "type": "string",
+                            "title": "URI",
+                            "description": "動画または音声のURI。"
+                        },
                         "path": {
                             "type": "string",
                             "title": "ファイルパス",
-                            "description": "ファイルが存在するパス。ルートはデバイスプラグインごとに違う。File APIで使用可能。"
+                            "description": "ファイルが存在するパス。ルートはデバイスプラグインごとに違う。"
                         },
                         "mimeType": {
                             "type": "string",
@@ -1428,6 +1429,27 @@
                     }
                 }
             }
+        },
+        "RecorderStopResponse": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/CommonResponse"
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "uri"
+                    ],
+                    "properties": {
+                        "uri": {
+                            "type": "string",
+                            "title": "URI",
+                            "description": "動画または音声のURI。"
+                        }
+                    }
+                }
+            ]
         },
         "RecorderControlResponse": {
             "type": "object",

--- a/api/mediaStreamRecording.json
+++ b/api/mediaStreamRecording.json
@@ -1396,8 +1396,6 @@
                     "description": "レコーディング情報",
                     "required": [
                         "status",
-                        "uri",
-                        "path",
                         "mimeType"
                     ],
                     "properties": {
@@ -1439,9 +1437,6 @@
                 },
                 {
                     "type": "object",
-                    "required": [
-                        "uri"
-                    ],
                     "properties": {
                         "uri": {
                             "type": "string",


### PR DESCRIPTION
## 修正内容
* 記録開始時点（record）でURIが利用できるケース⇒recordのレスポンスにURIを記載（オプション）
* 記録終了時点（stop）ののレスポンスにURIを記載（オプション）
* onRecordingChangeでの状態管理でURIをイベント通知、APIに依らない記録終了動作がある場合はこちらを利用