### PR TITLE
EVENT /videoChat/onCall API で発信元情報を配列で返すように修正

### DIFF
--- a/api/keyevent.json
+++ b/api/keyevent.json
@@ -506,8 +506,8 @@
                     "properties": {
                         "state": {
                             "type": "string",
-                            "title": "押されたKeyのID",
-                            "description": ""
+                            "title": "押された、もしくは離された時の状態",
+                            "description": "up:Keyが離された。<br>down:Keyが押された。"
                         },
                         "id": {
                             "type": "integer",

--- a/api/mediaStreamRecording.json
+++ b/api/mediaStreamRecording.json
@@ -826,6 +826,16 @@
                         },
                         "examples": {
                             "application/json": {
+                              "streams": [
+                                   {
+                                       "mimeType" : "video/x-mjpeg",
+                                       "uri" : "http://localhost:9000/xxxxxx"
+                                   },
+                                   {
+                                        "mimeType" : "video/x-rtp",
+                                        "uri" : "rtsp://localhost:8086"
+                                   }
+                               ],
                                 "result": 0,
                                 "product": "Example System",
                                 "version": "1.0.0",
@@ -1334,6 +1344,30 @@
                             "type": "string",
                             "title": "プレビュー配信URI",
                             "description": "開始したプレビューの配信用URI。形式はMotionJPEGとする。"
+                        },
+                        "streams": {
+                            "type": "array",
+                            "title": "ストリームのリスト",
+                            "description": "ストリーム情報の配列。",
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "mimeType",
+                                    "uri"
+                                ],
+                                "properties": {
+                                    "mimeType": {
+                                        "type": "string",
+                                        "title": "ストリームのMIMEType",
+                                        "description": "ストリームのMIMEType。"
+                                    },
+                                    "uri": {
+                                        "type": "string",
+                                        "title": "ストリームのURI",
+                                        "description": "ストリームのURI。"
+                                    }
+                                }
+                            }
                         },
                         "audio": {
                             "type": "object",

--- a/api/touch.json
+++ b/api/touch.json
@@ -850,7 +850,148 @@
                     }
                 }
             }
+        },
+        "/onTouchChange": {
+            "get": {
+                "operationId": "touchOnTouchChangeGet",
+                "x-type": "one-shot",
+                "summary": "デバイスでタッチされた座標と状態をイベントとして取得する。",
+                "description": "プラグイン側でキャッシュしている最新のイベントメッセージを1つ取得する。",
+                "parameters": [
+                    {
+                        "name": "serviceId",
+                        "description": "サービスID。",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/OnTouchChangeResponse"
+                        },
+                        "examples": {
+                            "application/json": {
+                                "result": 0,
+                                "product": "Example System",
+                                "version": "1.0.0",
+                                "touch": {
+                                    "touches": [
+                                        {
+                                            "x": 192,
+                                            "y": 168,
+                                            "id": 0
+                                        },
+                                        {
+                                            "x": 54,
+                                            "y": 200,
+                                            "id": 1
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "operationId": "touchOnTouchChangePut",
+                "x-type": "event",
+                "summary": "デバイスでタッチされた座標と状態をイベントとしての受信を開始する。",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "serviceId",
+                        "description": "サービスID。",
+                        "in": "formData",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "interval",
+                        "description": "イベント受信間隔。単位：mSec",
+                        "in": "formData",
+                        "required": false,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/EventRegistrationResponse"
+                        },
+                        "examples": {
+                            "application/json": {
+                                "result": 0,
+                                "product": "Example System",
+                                "version": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "x-event": {
+                    "schema": {
+                        "$ref": "#/definitions/OnTouchChangeEvent"
+                    },
+                    "examples": {
+                        "application/json": {
+                            "serviceId": "Host.dummyId.localhost.deviceconnect.org",
+                            "profile": "touch",
+                            "attribute": "ondoubletap",
+                            "touch": {
+                                "touches": [
+                                    {
+                                        "x": 192,
+                                        "y": 168,
+                                        "id": 0
+                                    },
+                                    {
+                                        "x": 54,
+                                        "y": 200,
+                                        "id": 1
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "touchOnTouchChangeDelete",
+                "x-type": "event",
+                "summary": "当該イベントの通知を停止する。",
+                "description": "",
+                "parameters": [
+                    {
+                        "name": "serviceId",
+                        "description": "サービスID。",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/EventUnregistrationResponse"
+                        },
+                        "examples": {
+                            "application/json": {
+                                "result": 0,
+                                "product": "Example System",
+                                "version": "1.0.0"
+                            }
+                        }
+                    }
+                }
+            }
         }
+
     },
     "definitions": {
         "OnTouchResponse": {
@@ -949,6 +1090,25 @@
                 "$ref": "#/definitions/OnTouchInfo"
             }]
         },
+        "OnTouchChangeResponse": {
+            "type": "object",
+            "allOf": [{
+                "$ref": "#/definitions/CommonResponse"
+            },{
+                "$ref": "#/definitions/OnTouchChangeInfo"
+            }]
+        },
+        "OnTouchChangeEvent": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/CommonEvent"
+                },
+                {
+                    "$ref": "#/definitions/OnTouchChangeInfo"
+                }
+            ]
+        },
         "OnTouchInfo": {
             "type": "object",
             "required": ["touch"],
@@ -987,6 +1147,46 @@
                         }
                     }
                 }
+            }
+        },
+        "OnTouchChangeInfo": {
+            "type": "object",
+            "required": [
+                "touches"
+            ],
+            "properties": {
+                "state": {
+                    "type": "string",
+                    "title": "タッチの状態",
+                    "description": "start:タッチを開始した。<br>end:タッチが終了した。<br>doubletap:ダブルタップが行われた。<br>move:タッチされ続けている。<br>cancel:タッチが中断された。<br>"
+                },
+                "touches": {
+                    "type": "array",
+                    "title": "タッチ情報の配列",
+                    "description": "各タッチに関する情報の配列。",
+                    "items": {
+                        "type": "object",
+                        "required": ["id", "x", "y"],
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "title": "ID",
+                                "description": "タッチを開始すると割り振られる、ユニーク（唯一）な識別番号。"
+                            },
+                            "x": {
+                                "type": "integer",
+                                "title": "x座標",
+                                "description": "デバイスが持つ空間の左上を原点としたx座標。"
+                            },
+                            "y": {
+                                "type": "integer",
+                                "title": "y座標",
+                                "description": "デバイスが持つ空間の左上を原点としたy座標。"
+                            }
+                        }
+                    }
+                }
+
             }
         },
         "EventRegistrationResponse": {

--- a/api/videoChat.json
+++ b/api/videoChat.json
@@ -806,167 +806,170 @@
             "required": ["oncall"],
             "properties": {
                 "oncall": {
-                    "type": "object",
-                    "title": "発信元情報",
-                    "required": ["name", "addressId"],
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "title": "デバイス名",
-                            "description": "発信元のデバイス名。"
-                        },
-                        "addressId": {
-                            "type": "string",
-                            "title": "アドレスID",
-                            "description": "発信元のアドレスID。"
-                        },
-                        "remote": {
-                            "type": "object",
-                            "title": "相手局リソース情報",
-                            "description": "相手局リソース情報",
-                            "properties": {
-                                "video": {
-                                    "type": "object",
-                                    "title": "映像関連情報",
-                                    "description": "映像関連情報",
-                                    "properties": {
-                                        "uri": {
-                                            "type": "string",
-                                            "title": "映像リソースURI",
-                                            "description": "映像のリソースURI。省略された場合は映像無し。但し、videoとaudioの両方が省略されることは無い"
-                                        },
-                                        "mimeType": {
-                                            "type": "string",
-                                            "title": "MIMEタイプ",
-                                            "description": "映像リソースのMIMEタイプ。"
-                                        },
-                                        "frameRate": {
-                                            "type": "number",
-                                            "title": "フレームレート",
-                                            "description": "映像リソースのフレームレート。"
-                                        },
-                                        "width": {
-                                            "type": "integer",
-                                            "title": "幅",
-                                            "description": "通知時点での幅（可変）"
-                                        },
-                                        "height": {
-                                            "type": "integer",
-                                            "title": "高さ",
-                                            "description": "通知時点での高さ（可変）"
+                    "type": "array",
+                    "title": "発信元情報一覧",
+                    "items": {
+                        "title": "発信元情報",
+                        "required": ["name", "addressId"],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "title": "デバイス名",
+                                "description": "発信元のデバイス名。"
+                            },
+                            "addressId": {
+                                "type": "string",
+                                "title": "アドレスID",
+                                "description": "発信元のアドレスID。"
+                            },
+                            "remote": {
+                                "type": "object",
+                                "title": "相手局リソース情報",
+                                "description": "相手局リソース情報",
+                                "properties": {
+                                    "video": {
+                                        "type": "object",
+                                        "title": "映像関連情報",
+                                        "description": "映像関連情報",
+                                        "properties": {
+                                            "uri": {
+                                                "type": "string",
+                                                "title": "映像リソースURI",
+                                                "description": "映像のリソースURI。省略された場合は映像無し。但し、videoとaudioの両方が省略されることは無い"
+                                            },
+                                            "mimeType": {
+                                                "type": "string",
+                                                "title": "MIMEタイプ",
+                                                "description": "映像リソースのMIMEタイプ。"
+                                            },
+                                            "frameRate": {
+                                                "type": "number",
+                                                "title": "フレームレート",
+                                                "description": "映像リソースのフレームレート。"
+                                            },
+                                            "width": {
+                                                "type": "integer",
+                                                "title": "幅",
+                                                "description": "通知時点での幅（可変）"
+                                            },
+                                            "height": {
+                                                "type": "integer",
+                                                "title": "高さ",
+                                                "description": "通知時点での高さ（可変）"
+                                            }
                                         }
-                                    }
-                                },
-                                "audio": {
-                                    "type": "object",
-                                    "title": "音声関連情報",
-                                    "description": "音声関連情報",
-                                    "properties": {
-                                        "uri": {
-                                            "type": "string",
-                                            "title": "音声リソースURI",
-                                            "description": "音声のリソースURI。省略された場合は音声無し。但し、videoとaudioの両方が省略されることは無い。"
-                                        },
-                                        "mimeType": {
-                                            "type": "string",
-                                            "title": "MIMEタイプ",
-                                            "description": "音声リソースのMIMEタイプ。"
-                                        },
-                                        "sampleRate": {
-                                            "type": "integer",
-                                            "title": "サンプルレート",
-                                            "description": "音声リソースのサンプルレート。"
-                                        },
-                                        "channels": {
-                                            "type": "integer",
-                                            "title": "チャンネル数",
-                                            "description": "音声リソースのチャンネル数。"
-                                        },
-                                        "sampleSize": {
-                                            "type": "integer",
-                                            "title": "サンプルサイズ",
-                                            "description": "音声リソースのサンプルサイズ。"
-                                        },
-                                        "blockSize": {
-                                            "type": "integer",
-                                            "title": "ブロックサイズ",
-                                            "description": "音声リソースのブロックサイズ。"
+                                    },
+                                    "audio": {
+                                        "type": "object",
+                                        "title": "音声関連情報",
+                                        "description": "音声関連情報",
+                                        "properties": {
+                                            "uri": {
+                                                "type": "string",
+                                                "title": "音声リソースURI",
+                                                "description": "音声のリソースURI。省略された場合は音声無し。但し、videoとaudioの両方が省略されることは無い。"
+                                            },
+                                            "mimeType": {
+                                                "type": "string",
+                                                "title": "MIMEタイプ",
+                                                "description": "音声リソースのMIMEタイプ。"
+                                            },
+                                            "sampleRate": {
+                                                "type": "integer",
+                                                "title": "サンプルレート",
+                                                "description": "音声リソースのサンプルレート。"
+                                            },
+                                            "channels": {
+                                                "type": "integer",
+                                                "title": "チャンネル数",
+                                                "description": "音声リソースのチャンネル数。"
+                                            },
+                                            "sampleSize": {
+                                                "type": "integer",
+                                                "title": "サンプルサイズ",
+                                                "description": "音声リソースのサンプルサイズ。"
+                                            },
+                                            "blockSize": {
+                                                "type": "integer",
+                                                "title": "ブロックサイズ",
+                                                "description": "音声リソースのブロックサイズ。"
+                                            }
                                         }
                                     }
                                 }
-                            }
-                        },
-                        "local": {
-                            "type": "object",
-                            "title": "自局リソース情報",
-                            "description": "自局リソース情報",
-                            "properties": {
-                                "video": {
-                                    "type": "object",
-                                    "title": "映像関連情報",
-                                    "description": "映像関連情報",
-                                    "properties": {
-                                        "uri": {
-                                            "type": "string",
-                                            "title": "映像リソースURI",
-                                            "description": "映像のリソースURI。省略された場合は映像無し。但し、videoとaudioの両方が省略されることは無い"
-                                        },
-                                        "mimeType": {
-                                            "type": "string",
-                                            "title": "MIMEタイプ",
-                                            "description": "映像リソースのMIMEタイプ。"
-                                        },
-                                        "frameRate": {
-                                            "type": "number",
-                                            "title": "フレームレート",
-                                            "description": "映像リソースのフレームレート。"
-                                        },
-                                        "width": {
-                                            "type": "integer",
-                                            "title": "幅",
-                                            "description": "通知時点での幅（可変）"
-                                        },
-                                        "height": {
-                                            "type": "integer",
-                                            "title": "高さ",
-                                            "description": "通知時点での高さ（可変）"
+                            },
+                            "local": {
+                                "type": "object",
+                                "title": "自局リソース情報",
+                                "description": "自局リソース情報",
+                                "properties": {
+                                    "video": {
+                                        "type": "object",
+                                        "title": "映像関連情報",
+                                        "description": "映像関連情報",
+                                        "properties": {
+                                            "uri": {
+                                                "type": "string",
+                                                "title": "映像リソースURI",
+                                                "description": "映像のリソースURI。省略された場合は映像無し。但し、videoとaudioの両方が省略されることは無い"
+                                            },
+                                            "mimeType": {
+                                                "type": "string",
+                                                "title": "MIMEタイプ",
+                                                "description": "映像リソースのMIMEタイプ。"
+                                            },
+                                            "frameRate": {
+                                                "type": "number",
+                                                "title": "フレームレート",
+                                                "description": "映像リソースのフレームレート。"
+                                            },
+                                            "width": {
+                                                "type": "integer",
+                                                "title": "幅",
+                                                "description": "通知時点での幅（可変）"
+                                            },
+                                            "height": {
+                                                "type": "integer",
+                                                "title": "高さ",
+                                                "description": "通知時点での高さ（可変）"
+                                            }
                                         }
-                                    }
-                                },
-                                "audio": {
-                                    "type": "object",
-                                    "title": "音声関連情報",
-                                    "description": "音声関連情報",
-                                    "properties": {
-                                        "uri": {
-                                            "type": "string",
-                                            "title": "音声リソースURI",
-                                            "description": "音声のリソースURI。省略された場合は音声無し。但し、videoとaudioの両方が省略されることは無い。"
-                                        },
-                                        "mimeType": {
-                                            "type": "string",
-                                            "title": "MIMEタイプ",
-                                            "description": "音声リソースのMIMEタイプ。"
-                                        },
-                                        "sampleRate": {
-                                            "type": "integer",
-                                            "title": "サンプルレート",
-                                            "description": "音声リソースのサンプルレート。"
-                                        },
-                                        "channels": {
-                                            "type": "integer",
-                                            "title": "チャンネル数",
-                                            "description": "音声リソースのチャンネル数。"
-                                        },
-                                        "sampleSize": {
-                                            "type": "integer",
-                                            "title": "サンプルサイズ",
-                                            "description": "音声リソースのサンプルサイズ。"
-                                        },
-                                        "blockSize": {
-                                            "type": "integer",
-                                            "title": "ブロックサイズ",
-                                            "description": "音声リソースのブロックサイズ。"
+                                    },
+                                    "audio": {
+                                        "type": "object",
+                                        "title": "音声関連情報",
+                                        "description": "音声関連情報",
+                                        "properties": {
+                                            "uri": {
+                                                "type": "string",
+                                                "title": "音声リソースURI",
+                                                "description": "音声のリソースURI。省略された場合は音声無し。但し、videoとaudioの両方が省略されることは無い。"
+                                            },
+                                            "mimeType": {
+                                                "type": "string",
+                                                "title": "MIMEタイプ",
+                                                "description": "音声リソースのMIMEタイプ。"
+                                            },
+                                            "sampleRate": {
+                                                "type": "integer",
+                                                "title": "サンプルレート",
+                                                "description": "音声リソースのサンプルレート。"
+                                            },
+                                            "channels": {
+                                                "type": "integer",
+                                                "title": "チャンネル数",
+                                                "description": "音声リソースのチャンネル数。"
+                                            },
+                                            "sampleSize": {
+                                                "type": "integer",
+                                                "title": "サンプルサイズ",
+                                                "description": "音声リソースのサンプルサイズ。"
+                                            },
+                                            "blockSize": {
+                                                "type": "integer",
+                                                "title": "ブロックサイズ",
+                                                "description": "音声リソースのブロックサイズ。"
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
# 概要
VideoChat プロファイルの onCall イベントについて、複数の接続先がある可能性を制限しないようにするために、接続先の型を array に変更しました。

既存のWebRTCプラグインでは対応済みです。

# 動作確認方法
1. [Swagger Editor](https://editor.swagger.io/) に videoChat.json をインポートしてもエラーが発生しないこと。
1. OnCallInfo モデルの oncall プロパティの型が array 、名前が「発信元情報一覧」となっていること。